### PR TITLE
Setup EF Core infrastructure with SQLite and In-Memory

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": "dotnet build Deesix.Exe.sln"
+  }
+}

--- a/src/Deesix.ConsoleUI/Program.cs
+++ b/src/Deesix.ConsoleUI/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Spectre.Console;
+using Deesix.Product.Infrastructure;
 
 namespace Deesix.ConsoleUI;
 
@@ -14,8 +15,11 @@ internal class Program
         {
             var host = Host
                 .CreateDefaultBuilder(args)
-                .ConfigureServices((hostContext, services) => 
-                    services.AddDeesixConsoleUI(hostContext.Configuration)).Build();
+                .ConfigureServices((hostContext, services) =>
+                {
+                    string connectionString = "Data Source=deesix.db";
+                    services.AddDeesixInfrastructure(connectionString);
+                }).Build();
             
             using (var scope = host.Services.CreateScope())
             {

--- a/src/Deesix.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Deesix.Infrastructure/ServiceCollectionExtensions.cs
@@ -39,6 +39,33 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    public static IServiceCollection AddDeesixInfrastructure(this IServiceCollection services, string connectionString)
+    {
+        services.AddDbContext<ApplicationDbContext>(options =>
+            options.UseSqlite(connectionString));
+
+        services.AddScoped(typeof(IRepository<>), typeof(GenericRepository<>));
+
+        return services;
+    }
+
+    public static IServiceCollection AddInMemoryDeesixContext(this IServiceCollection services)
+    {
+        var descriptor = services.SingleOrDefault(
+            d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+        if (descriptor != null)
+        {
+            services.Remove(descriptor);
+        }
+
+        services.AddDbContext<ApplicationDbContext>(options =>
+        {
+            options.UseInMemoryDatabase("DeesixTestDb");
+        });
+
+        return services;
+    }
+
     private static bool IsTestEnvironment() => 
         Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Test";
 }

--- a/test/Deesix.Tests/TestServiceCollectionExtensions.cs
+++ b/test/Deesix.Tests/TestServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Deesix.Tests
+{
+    public static class TestServiceCollectionExtensions
+    {
+        public static IServiceCollection AddInMemoryDeesixContext(
+            this IServiceCollection services)
+        {
+            // Remove existing DbContext registration if any
+            var descriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<Deesix.Infrastructure.DataAccess.ApplicationDbContext>));
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+
+            // Register InMemory DB
+            services.AddDbContext<Deesix.Infrastructure.DataAccess.ApplicationDbContext>(options =>
+            {
+                options.UseInMemoryDatabase("DeesixTestDb");
+            });
+
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
Add EF Core and SQLite configuration to the console application.

* Modify `src/Deesix.ConsoleUI/Program.cs` to configure EF Core with SQLite for production and remove the call to `AddDeesixConsoleUI`.
* Add `AddDeesixInfrastructure` and `AddInMemoryDeesixContext` methods in `src/Deesix.Infrastructure/ServiceCollectionExtensions.cs` to register EF Core and repositories in the DI container and configure EF Core to use an In-Memory database for testing.
* Add `test/Deesix.Tests/TestServiceCollectionExtensions.cs` to configure EF Core to use an In-Memory database for testing.
* Add `.devcontainer/devcontainer.json` to include a build task for the solution.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PeterMilovcik/Deesix.Exe/pull/3?shareId=3336b0b3-3ac7-4a8f-a263-8a25c192c9a9).